### PR TITLE
refactor: Externalize CSS and improve navigation flow

### DIFF
--- a/public/css/chat.css
+++ b/public/css/chat.css
@@ -1,0 +1,141 @@
+/* --- Estilos del Chat --- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  display: grid;
+  place-content: center;
+  height: 100vh;
+  padding: 36px 36px 100px 36px;
+  grid-template-rows: 1fr;
+}
+
+#messages {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: scroll;
+  height: 100%;
+  scroll-behavior: smooth;
+  padding-bottom: 48px;
+}
+
+#messages>li {
+  padding: .5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+#messages > li.sent {
+  align-items: flex-end;
+}
+
+/* Estilos para el modo claro */
+#messages > li:not(.sent):nth-child(odd) {
+  background: #f0f0f0;
+}
+
+/* Estilos para el modo oscuro, usando las capacidades del navegador */
+@media (prefers-color-scheme: dark) {
+  #messages > li:not(.sent):nth-child(odd) {
+    background: #2c2c2c;
+  }
+}
+
+#chat {
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  overflow: hidden;
+  width: 350px;
+  height: 100%;
+  position: relative;
+}
+
+#form {
+  bottom: 0;
+  display: flex;
+  height: 48px;
+  left: 0;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+}
+
+#input {
+  border-radius: 9999px;
+  border: 1px solid #eee;
+  flex: 1;
+  margin: 4px;
+  padding: 0 8px;
+}
+
+#input:focus {
+  outline: 0;
+}
+
+#form>button {
+  background: #09f;
+  color: #fff;
+  border: 0;
+  margin: 4px;
+  border-radius: 4px;
+}
+
+#form>button:hover {
+  background: #0cf;
+}
+
+/* --- Estilos para la Cabecera del Chat y Logout --- */
+.chat-header {
+  padding: 10px;
+  background: #f0f0f0;
+  border-bottom: 1px solid #ccc;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.chat-header span {
+  font-weight: bold;
+}
+
+#logout-button {
+  padding: 5px 10px;
+  background-color: #dc3545; /* Rojo para una acción destructiva/de salida */
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+#logout-button:hover {
+  background-color: #c82333;
+}
+
+/* Ajuste para que el chat use flexbox y la cabecera/mensajes/formulario se ordenen correctamente */
+#chat {
+  display: flex;
+  flex-direction: column;
+}
+
+#messages {
+  flex-grow: 1; /* Esto hace que la lista de mensajes ocupe todo el espacio vertical disponible */
+}
+
+
+@media (prefers-color-scheme: dark) {
+  .chat-header {
+    background: #2c2c2c;
+    border-bottom: 1px solid #444;
+  }
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,0 +1,105 @@
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+/* Definimos que nuestra página soporta ambos temas, claro y oscuro. */
+:root {
+    color-scheme: light dark;
+}
+
+body {
+    font-family: "Roboto", sans-serif;
+    background-color: #f5f5f5; /* Fondo para el modo claro */
+    color: #121212; /* Texto para el modo claro */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 100vh;
+}
+
+.form-container {
+    background-color: #fff; /* Fondo de los formularios en modo claro */
+    padding: 20px;
+    margin: 10px;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    transition: background-color 0.3s;
+}
+
+form h2 {
+    margin-bottom: 20px;
+    font-size: 24px;
+    text-align: center;
+}
+
+label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+
+input {
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 20px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #fff;
+    color: #121212;
+    transition: background-color 0.3s, color 0.3s, border-color 0.3s;
+}
+
+button {
+    width: 100%;
+    padding: 10px;
+    background-color: #28a745;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 16px;
+    transition: background-color 0.3s;
+}
+
+button:hover{
+    background-color: #218838;
+}
+
+/* --- Media Query para el Modo Oscuro --- */
+/* Estas reglas se aplicarán solo si el usuario tiene el modo oscuro activado en su sistema. */
+@media (prefers-color-scheme: dark) {
+    body {
+        background-color: #121212;
+        color: #f5f5f5;
+    }
+
+    .form-container {
+        background-color: #1e1e1e;
+        box-shadow: 0 2px 10px rgba(255, 255, 255, 0.1);
+    }
+
+    input {
+        background-color: #2c2c2c;
+        color: #f5f5f5;
+        border-color: #444;
+    }
+
+    button {
+        background-color: #218838;
+    }
+
+    button:hover {
+        background-color: #28a745;
+    }
+}

--- a/public/js/chat.js
+++ b/public/js/chat.js
@@ -58,3 +58,19 @@ form.addEventListener('submit', (e) => {
     input.value = ''
   }
 })
+
+// --- Lógica para Cerrar Sesión ---
+const logoutButton = document.getElementById('logout-button')
+
+logoutButton.addEventListener('click', () => {
+  fetch('/logout', {
+    method: 'POST'
+  }).then(res => {
+    if (res.ok) {
+      // Si el logout es exitoso, redirigimos a la página principal.
+      window.location.href = '/'
+    }
+  }).catch(error => {
+    console.error('Error al cerrar sesión:', error)
+  })
+})

--- a/views/chat.ejs
+++ b/views/chat.ejs
@@ -6,105 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Chat Protegido</title>
 
-  <style>
-    /* --- Estilos del Chat --- */
-    /* Estos estilos son los mismos que tenías en client/index.html */
-    /* Los he movido aquí para que estén junto a su estructura HTML. */
-    *,
-    *::before,
-    *::after {
-      box-sizing: border-box;
-    }
-
-    :root {
-      color-scheme: light dark;
-    }
-
-    body {
-      margin: 0;
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-      display: grid;
-      place-content: center;
-      height: 100vh;
-      padding: 36px 36px 100px 36px;
-      grid-template-rows: 1fr;
-    }
-
-    #messages {
-      list-style-type: none;
-      margin: 0;
-      padding: 0;
-      overflow-y: scroll;
-      height: 100%;
-      scroll-behavior: smooth;
-      padding-bottom: 48px;
-    }
-
-    #messages>li {
-      padding: .5rem;
-      display: flex;
-      flex-direction: column;
-    }
-
-    #messages > li.sent {
-      align-items: flex-end;
-    }
-
-    /* Estilos para el modo claro */
-    #messages > li:not(.sent):nth-child(odd) {
-      background: #f0f0f0;
-    }
-
-    /* Estilos para el modo oscuro, usando las capacidades del navegador */
-    @media (prefers-color-scheme: dark) {
-      #messages > li:not(.sent):nth-child(odd) {
-        background: #2c2c2c;
-      }
-    }
-
-    #chat {
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      overflow: hidden;
-      width: 350px;
-      height: 100%;
-      position: relative;
-    }
-
-    #form {
-      bottom: 0;
-      display: flex;
-      height: 48px;
-      left: 0;
-      padding: 4px;
-      position: absolute;
-      right: 0;
-    }
-
-    #input {
-      border-radius: 9999px;
-      border: 1px solid #eee;
-      flex: 1;
-      margin: 4px;
-      padding: 0 8px;
-    }
-
-    #input:focus {
-      outline: 0;
-    }
-
-    #form>button {
-      background: #09f;
-      color: #fff;
-      border: 0;
-      margin: 4px;
-      border-radius: 4px;
-    }
-
-    #form>button:hover {
-      background: #0cf;
-    }
-  </style>
+  <!-- Vinculamos la hoja de estilos externa para el chat -->
+  <link rel="stylesheet" href="/css/chat.css">
 </head>
 
 <body>
@@ -117,6 +20,10 @@
 
   <!-- Esta es la estructura HTML del chat, también de client/index.html -->
   <section id="chat">
+    <header class="chat-header">
+      <span>Bienvenido, <%= user.username %></span>
+      <button id="logout-button">Cerrar Sesión</button>
+    </header>
     <ul id="messages"></ul>
     <form id="form">
       <input type="text" name="message" id="input" placeholder="Escribe un mensaje..." autocomplete="off" />

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -8,73 +8,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <style>
-        *,
-        *::before,
-        *::after {
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: "Roboto", sans-serif;
-            background-color: #f5f5f5;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100hv;
-            margin: 0;
-        }
-
-        .container { 
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-            height: 100vh;
-        }
-
-        .form-container {
-            background-color: #fff;
-            padding: 20px;
-            margin: 10px;
-            border-radius: 8px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-        }
-
-        form h2 {
-            margin-bottom: 20px;
-            font-size: 24px;
-            text-align: center;
-        }
-
-        label {
-            display: block;
-            margin-bottom: 5px;
-            font-weight: bold;
-        }
-
-        input{
-            width: 100%;
-            padding: 10px;
-            margin-bottom: 20px;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-        }
-
-        button {
-            width: 100%;
-            padding: 10px;
-            background-color: #28a745;
-            color: #fff;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            font-size: 16px;
-        }
-
-        button:hover{
-            background-color: #218838;
-        }
-    </style>
+    <!-- Vinculamos la hoja de estilos principal -->
+    <link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
     <div class="container">
@@ -146,7 +81,7 @@
                     loginSpan.innerText = 'Sesion Iniciada... Entrando...'
                     loginSpan.style.color = 'green'
                     setTimeout(() => {
-                        window.location.href = '/protected'
+                        window.location.href = '/chat'
                     }, 1200)
                 }else{
                     loginSpan.innerText = 'Error al iniciar sesion'
@@ -188,7 +123,7 @@
             })
               .then(res => {
                 if(res.ok){
-                    window.location.href = '/protected'
+                    window.location.href = '/chat'
                 }else{
                     loginSpan.innerText = 'Error al iniciar sesion'
                     loginSpan.style.color = 'red'

--- a/views/protected.ejs
+++ b/views/protected.ejs
@@ -3,10 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Protected Area</title>
+    <!-- Vinculamos la hoja de estilos principal para mantener la consistencia -->
+    <link rel="stylesheet" href="/css/main.css">
 </head>
 <body>
-    <h1>Hello <%= username %></h1>
-    <h2>Este contenido esta protegido</h2>
+    <div class="container">
+        <div class="form-container">
+            <h1>Hola <%= username %>!</h1>
+            <h2>Este contenido está protegido.</h2>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
This commit refactors the frontend to improve code organization and user experience.

Key changes:
- All inline CSS from EJS views (`index.ejs`, `chat.ejs`) has been moved to external stylesheets in the `public/css/` directory (`main.css`, `chat.css`).
- Dark mode support has been added to `main.css` for a consistent theme across the application.
- All views have been updated to link to their corresponding external stylesheets.
- The client-side login and registration scripts now redirect you to `/chat` upon successful authentication, improving the user flow.
- A logout button has been added to the chat view, styled, and connected to the `/logout` endpoint, allowing you to easily sign out.